### PR TITLE
android_p9.0.0: update libwifi_hal and wpa_supplicant_lib for Android…

### DIFF
--- a/mac80211/wifi_hal/Android.mk
+++ b/mac80211/wifi_hal/Android.mk
@@ -18,12 +18,22 @@ LOCAL_PATH := $(call my-dir)
 # ============================================================
 include $(CLEAR_VARS)
 
-LOCAL_CFLAGS := -Wno-unused-parameter
+LOCAL_CFLAGS := \
+    -Wall \
+    -Werror \
+    -Wno-format \
+    -Wno-reorder \
+    -Wno-unused-function \
+    -Wno-unused-parameter \
+    -Wno-unused-private-field \
+    -Wno-unused-variable \
 
 LOCAL_C_INCLUDES += \
 	external/libnl/include \
 	$(call include-path-for, libhardware_legacy)/hardware_legacy \
 	external/wpa_supplicant_8/src/drivers
+
+LOCAL_HEADER_LIBRARIES := libutils_headers liblog_headers
 
 LOCAL_SRC_FILES := \
 	wifi_hal.cpp \

--- a/mac80211/wifi_hal/common.h
+++ b/mac80211/wifi_hal/common.h
@@ -6,7 +6,7 @@
 
 #define LOG_TAG  "WifiHAL"
 
-#include <utils/Log.h>
+#include <log/log.h>
 #include "nl80211_copy.h"
 #include "sync.h"
 

--- a/mac80211/wifi_hal/link_layer_stats.cpp
+++ b/mac80211/wifi_hal/link_layer_stats.cpp
@@ -20,7 +20,7 @@
 
 #define LOG_TAG  "WifiHAL"
 
-#include <utils/Log.h>
+#include <log/log.h>
 
 #include "wifi_hal.h"
 #include "common.h"

--- a/mac80211/wifi_hal/wifi_hal.cpp
+++ b/mac80211/wifi_hal/wifi_hal.cpp
@@ -25,7 +25,7 @@
 
 #define LOG_TAG  "WifiHAL"
 
-#include <utils/Log.h>
+#include <log/log.h>
 
 #include "wifi_hal.h"
 #include "common.h"
@@ -41,6 +41,13 @@
 
 #define WIFI_HAL_CMD_SOCK_PORT       644
 #define WIFI_HAL_EVENT_SOCK_PORT     645
+
+/*
+ * Defines for wifi_wait_for_driver_ready()
+ * Specify durations between polls and max wait time
+ */
+#define POLL_DRIVER_DURATION_US (100000)
+#define POLL_DRIVER_MAX_TIME_MS (10000)
 
 static void internal_event_handler(wifi_handle handle, int events);
 static int internal_no_seq_check(nl_msg *msg, void *arg);
@@ -133,6 +140,7 @@ wifi_error init_wifi_vendor_hal_func_table(wifi_hal_fn *fn)
         return WIFI_ERROR_UNKNOWN;
     }
     fn->wifi_initialize = wifi_initialize;
+    fn->wifi_wait_for_driver_ready = wifi_wait_for_driver_ready;
     fn->wifi_cleanup = wifi_cleanup;
     fn->wifi_event_loop = wifi_event_loop;
     fn->wifi_get_supported_feature_set = wifi_get_supported_feature_set;
@@ -286,6 +294,25 @@ wifi_error wifi_initialize(wifi_handle *handle)
 
     ALOGI("Initialized Wifi HAL Successfully; vendor cmd = %d", NL80211_CMD_VENDOR);
     return WIFI_SUCCESS;
+}
+
+wifi_error wifi_wait_for_driver_ready(void)
+{
+    // This function will wait to make sure basic client netdev is created
+    // Function times out after 10 seconds
+    int count = (POLL_DRIVER_MAX_TIME_MS * 1000) / POLL_DRIVER_DURATION_US;
+    FILE *fd;
+
+    do {
+        if ((fd = fopen("/sys/class/net/wlan0", "r")) != NULL) {
+            fclose(fd);
+            return WIFI_SUCCESS;
+        }
+        usleep(POLL_DRIVER_DURATION_US);
+    } while(--count > 0);
+
+    ALOGE("Timed out waiting on Driver ready ... ");
+    return WIFI_ERROR_TIMED_OUT;
 }
 
 static int wifi_add_membership(wifi_handle handle, const char *group)

--- a/mac80211/wifi_hal/wifi_logger.cpp
+++ b/mac80211/wifi_hal/wifi_logger.cpp
@@ -21,13 +21,11 @@
 
 #define LOG_TAG  "WifiHAL"
 
-#include <utils/Log.h>
+#include <log/log.h>
 
 #include "wifi_hal.h"
 #include "common.h"
 #include "cpp_bindings.h"
-
-using namespace android;
 
 typedef enum {
     LOGGER_START_LOGGING = ANDROID_NL80211_SUBCMD_DEBUG_RANGE_START,

--- a/mac80211/wifi_hal/wifi_offload.cpp
+++ b/mac80211/wifi_hal/wifi_offload.cpp
@@ -22,13 +22,11 @@
 
 #define LOG_TAG  "WifiHAL"
 
-#include <utils/Log.h>
+#include <log/log.h>
 
 #include "wifi_hal.h"
 #include "common.h"
 #include "cpp_bindings.h"
-
-using namespace android;
 
 typedef enum {
     WIFI_OFFLOAD_START_MKEEP_ALIVE = ANDROID_NL80211_SUBCMD_WIFI_OFFLOAD_RANGE_START,

--- a/mac80211/wpa_supplicant_lib/Android.mk
+++ b/mac80211/wpa_supplicant_lib/Android.mk
@@ -22,7 +22,7 @@ ifneq ($(BOARD_WPA_SUPPLICANT_DRIVER),)
   CONFIG_DRIVER_$(BOARD_WPA_SUPPLICANT_DRIVER) := y
 endif
 
-L_CFLAGS = -DCONFIG_DRIVER_CUSTOM -DWPA_SUPPLICANT_$(WPA_SUPPLICANT_VERSION)
+L_CFLAGS = -DCONFIG_DRIVER_CUSTOM -DWPA_SUPPLICANT_$(WPA_SUPPLICANT_VERSION) -Wno-unused-parameter
 L_SRC :=
 
 ifdef CONFIG_NO_STDOUT_DEBUG
@@ -55,24 +55,25 @@ endif
 
 INCLUDES = $(WPA_SUPPL_DIR) \
     $(WPA_SUPPL_DIR)/src \
+    $(WPA_SUPPL_DIR)/src/drivers \
     $(WPA_SUPPL_DIR)/src/common \
     $(WPA_SUPPL_DIR)/src/drivers \
     $(WPA_SUPPL_DIR)/src/l2_packet \
     $(WPA_SUPPL_DIR)/src/utils \
-    $(WPA_SUPPL_DIR)/src/wps
+    $(WPA_SUPPL_DIR)/src/wps \
+    external/libnl-headers
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := lib_driver_cmd_wl12xx
 LOCAL_MODULE_TAGS := eng
 LOCAL_SHARED_LIBRARIES := libc libcutils
 ifneq ($(wildcard external/libnl),)
-INCLUDES += external/libnl/include
 LOCAL_SHARED_LIBRARIES += libnl
 else
-INCLUDES += external/libnl-headers
 LOCAL_STATIC_LIBRARIES := libnl_2
 endif
 LOCAL_CFLAGS := $(L_CFLAGS)
 LOCAL_SRC_FILES := $(L_SRC)
 LOCAL_C_INCLUDES := $(INCLUDES)
+LOCAL_VENDOR_MODULE := true
 include $(BUILD_STATIC_LIBRARY)

--- a/mac80211/wpa_supplicant_lib/driver_mac80211_nl.c
+++ b/mac80211/wpa_supplicant_lib/driver_mac80211_nl.c
@@ -12,6 +12,10 @@
 #include <netlink/msg.h>
 #include <netlink/attr.h>
 
+// un-define __bitwise because the macro is re-defined in another
+// header file (external/wpa_supplicant_8/wpa_supplicant/src/utils/common.h)
+#undef __bitwise
+
 #include "linux_wext.h"
 #include "common.h"
 #include "driver.h"
@@ -33,6 +37,9 @@
 #define BLUETOOTH_COEXISTENCE_MODE_DISABLED  1
 #define BLUETOOTH_COEXISTENCE_MODE_SENSE     2
 
+// this global variable and function are not used - un-define
+// them to prevent a compiler warning/error
+#if 0
 static int g_drv_errors = 0;
 
 static void wpa_driver_send_hang_msg(struct wpa_driver_nl80211_data *drv)
@@ -43,6 +50,7 @@ static void wpa_driver_send_hang_msg(struct wpa_driver_nl80211_data *drv)
 		wpa_msg(drv->ctx, MSG_INFO, WPA_EVENT_DRIVER_STATE "HANGED");
 	}
 }
+#endif
 
 static int wpa_driver_toggle_btcoex_state(char state)
 {
@@ -64,7 +72,6 @@ int wpa_driver_nl80211_driver_cmd(void *priv, char *cmd, char *buf,
 {
 	struct i802_bss *bss = priv;
 	struct wpa_driver_nl80211_data *drv = bss->drv;
-	struct ifreq ifr;
 	int ret = 0;
 
 	if (os_strcasecmp(cmd, "STOP") == 0) {


### PR DESCRIPTION
This patch pulls in the necessary modifications to allow the libwifi_hal
and wpa_supplicant_lib source compile under Android Pie (9.0.0).  These
libraries are necessary to get the TI WL18XX module to integrate with
Android via the new HIDL interface first defined in Oreo (8.0.0) and which
has a few slight modifications in Android Pie.